### PR TITLE
Fixes error when invoking fetchTest

### DIFF
--- a/js-for-survey123/src/index.js
+++ b/js-for-survey123/src/index.js
@@ -14,7 +14,7 @@ export function importJson() {
 }
 
 export function fetchTest() {
-  console.log(`\`${globals.libraryName}.importText\` method invoked`);
+  console.log(`\`${globals.libraryName}.fetchTest\` method invoked`);
   return fetchSync('http://aero.esri.com/arcgis/rest/services?f=pjson').json()
     .currentVersion;
 }

--- a/js-for-survey123/src/survey123/polyfills/Promise.js
+++ b/js-for-survey123/src/survey123/polyfills/Promise.js
@@ -265,11 +265,12 @@ Promise.race = function(arr) {
 // Use polyfill for setImmediate for performance gains
 Promise._immediateFn =
   // @ts-ignore
+  /* EDITED: `setImmediate` is in global scope, but uses `setTimeout` (which is not)
   (typeof setImmediate === 'function' &&
     function(fn) {
       // @ts-ignore
       setImmediate(fn);
-    }) ||
+    }) ||*/
   function(fn) {
     setTimeoutFunc(fn, 0);
 };


### PR DESCRIPTION
Fixes a bug with `fetchSync` and `Promise` which was introduced in a newer versions of S123 (due to addition of `setImmediate` in global scope)